### PR TITLE
Generate installable artifacts

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -9,14 +9,26 @@ pipelines:
   primary:
     description: Runs JavaScript tests, and verifies iOS and Android builds
     stages:
-    - test-and-build-stage: {}
+    - test-and-build-debug: {}
+  deploy:
+    stages:
+      - test-and-build-release: {}
+    
+
 stages:
-  test-and-build-stage:
+  test-and-build-debug:
     abort_on_fail: true
     workflows:
     - test-js: {}
-    - build-ios: {}
-    - build-android: {}
+    - deploy-ios-debug: {}
+    - deploy-android-debug: {}
+  test-and-build-release:
+    abort_on_fail: true
+    workflows:
+    - test-js: {}
+    - deploy-ios-release: {}
+    - deploy-android-release: {}
+
 workflows:
   _setup:
     steps:
@@ -26,6 +38,7 @@ workflows:
         inputs:
         - command: install
     - save-npm-cache@1: {}
+
   test-js:
     before_run:
     - _setup
@@ -34,7 +47,8 @@ workflows:
         title: Run tests
         inputs:
         - command: test
-  build-ios:
+
+  deploy-ios-debug:
     before_run:
     - _setup
     description: Builds the iOS version of the app for use in Simulators
@@ -51,8 +65,10 @@ workflows:
         - scheme: BitriseReactNativeSample
         - simulator_device: iPhone 13
         - configuration: Debug
+    - deploy-to-bitrise-io@2: {}
     - save-cocoapods-cache@1: {}
-  build-android:
+
+  deploy-android-debug:
     before_run:
     - _setup
     description: Builds the Android version of the app for use in emulators
@@ -67,6 +83,48 @@ workflows:
         - module: app
         - project_location: android
         - variant: debug
+    - deploy-to-bitrise-io@2: {}
+    - save-gradle-cache@1: {}
+    meta:
+      bitrise.io:
+        stack: linux-docker-android-20.04
+
+  deploy-ios-release:
+    before_run:
+    - _setup
+    description: Builds the iOS version of the app for use in Simulators
+    steps:
+    - react-native-bundle@1:
+        inputs:
+        - entry_file: index.js
+        - platform: ios
+    - restore-cocoapods-cache@1: {}
+    - cocoapods-install@2: {}
+    - xcode-build-for-simulator@0:
+        inputs:
+        - project_path: ios/BitriseReactNativeSample.xcworkspace
+        - scheme: BitriseReactNativeSample
+        - simulator_device: iPhone 13
+        - configuration: Release
+    - deploy-to-bitrise-io@2: {}
+    - save-cocoapods-cache@1: {}
+
+  deploy-android-release:
+    before_run:
+    - _setup
+    description: Builds the Android version of the app for use in emulators
+    steps:
+    - react-native-bundle@1:
+        inputs:
+        - entry_file: index.js
+        - platform: android
+    - restore-gradle-cache@1: {}
+    - android-build@1:
+        inputs:
+        - module: app
+        - project_location: android
+        - variant: release
+    - deploy-to-bitrise-io@2: {}
     - save-gradle-cache@1: {}
     meta:
       bitrise.io:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -35,11 +35,14 @@ workflows:
     - git-clone@7: {}
     - restore-npm-cache@1: {}
     - npm@1:
+        title: Install dependencies
         inputs:
         - command: install
     - save-npm-cache@1: {}
 
   test-js:
+    envs:
+    - JEST_JUNIT_OUTPUT_DIR: $BITRISE_DEPLOY_DIR
     before_run:
     - _setup
     steps:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -19,13 +19,13 @@ stages:
   test-and-build-debug:
     abort_on_fail: true
     workflows:
-    - _test-js: {}
+    - test-js: {}
     - deploy-ios-debug: {}
     - deploy-android-debug: {}
   test-and-build-release:
     abort_on_fail: true
     workflows:
-    - _test-js: {}
+    - test-js: {}
     - deploy-ios-release: {}
     - deploy-android-release: {}
 
@@ -39,7 +39,7 @@ workflows:
         - command: install
     - save-npm-cache@1: {}
 
-  _test-js:
+  test-js:
     before_run:
     - _setup
     steps:
@@ -52,7 +52,7 @@ workflows:
   primary:
     description: Runs JavaScript tests and deploys a test report.
     steps:
-    - _test-js: {}
+    - test-js: {}
 
   deploy-ios-debug:
     before_run:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -5,17 +5,17 @@ project_type: react-native
 trigger_map:
 - pull_request_source_branch: "*"
   pipeline: primary
+
 pipelines:
-  primary:
-    description: Runs JavaScript tests, and verifies iOS and Android builds
+  deploy-demo:
+    description: Runs JavaScript tests, and verifies iOS and Android debug builds
     stages:
     - test-and-build-debug: {}
   deploy:
     stages:
       - test-and-build-release: {}
-    
 
-stages:
+stages:    
   test-and-build-debug:
     abort_on_fail: true
     workflows:
@@ -49,10 +49,15 @@ workflows:
         - command: test
     - deploy-to-bitrise-io@2: {}
 
+  primary:
+    description: Runs JavaScript tests and deploys a test report.
+    steps:
+    - test-js: {}
+
   deploy-ios-debug:
     before_run:
     - _setup
-    description: Builds the iOS version of the app for use in Simulators
+    description: Builds the iOS version of the app for use in simulators
     steps:
     - react-native-bundle@1:
         inputs:
@@ -93,13 +98,12 @@ workflows:
   deploy-ios-release:
     before_run:
     - _setup
-    description: Builds the iOS version of the app for use in Simulators
+    description: Builds a release version of the iOS app
     steps:
     - react-native-bundle@1:
         inputs:
         - entry_file: index.js
         - platform: ios
-    - restore-cocoapods-cache@1: {}
     - cocoapods-install@2: {}
     - xcode-build-for-simulator@0:
         inputs:
@@ -108,25 +112,22 @@ workflows:
         - simulator_device: iPhone 13
         - configuration: Release
     - deploy-to-bitrise-io@2: {}
-    - save-cocoapods-cache@1: {}
 
   deploy-android-release:
     before_run:
     - _setup
-    description: Builds the Android version of the app for use in emulators
+    description: Builds a release version of the Android app
     steps:
     - react-native-bundle@1:
         inputs:
         - entry_file: index.js
         - platform: android
-    - restore-gradle-cache@1: {}
     - android-build@1:
         inputs:
         - module: app
         - project_location: android
         - variant: release
     - deploy-to-bitrise-io@2: {}
-    - save-gradle-cache@1: {}
     meta:
       bitrise.io:
         stack: linux-docker-android-20.04

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -50,6 +50,7 @@ workflows:
         - command: run test-ci
     - custom-test-results-export:
         inputs:
+        - test_name: Demo Test
         - search_pattern: test-report.junit.xml
     - deploy-to-bitrise-io@2: {}
 

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -49,7 +49,7 @@ workflows:
     - npm@1:
         title: Run tests
         inputs:
-        - command: test-ci
+        - command: run test-ci
     - deploy-to-bitrise-io@2: {}
 
   primary:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -51,7 +51,7 @@ workflows:
     - custom-test-results-export:
         inputs:
         - test_name: Demo Test
-        - search_pattern: *junit.xml
+        - search_pattern: "*/reports/*"
     - deploy-to-bitrise-io@2: {}
 
   primary:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -4,7 +4,7 @@ default_step_lib_source: https://github.com/bitrise-io/bitrise-steplib.git
 project_type: react-native
 trigger_map:
 - pull_request_source_branch: "*"
-  pipeline: primary
+  workflow: primary
 
 pipelines:
   deploy-demo:
@@ -13,7 +13,7 @@ pipelines:
     - test-and-build-debug: {}
   deploy:
     stages:
-      - test-and-build-release: {}
+    - test-and-build-release: {}
 
 stages:    
   test-and-build-debug:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -47,6 +47,7 @@ workflows:
         title: Run tests
         inputs:
         - command: test
+    - deploy-to-bitrise-io@2: {}
 
   deploy-ios-debug:
     before_run:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -46,7 +46,7 @@ workflows:
     - npm@1:
         title: Run tests
         inputs:
-        - command: test
+        - command: test-ci
     - deploy-to-bitrise-io@2: {}
 
   primary:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -19,13 +19,13 @@ stages:
   test-and-build-debug:
     abort_on_fail: true
     workflows:
-    - test-js: {}
+    - _test-js: {}
     - deploy-ios-debug: {}
     - deploy-android-debug: {}
   test-and-build-release:
     abort_on_fail: true
     workflows:
-    - test-js: {}
+    - _test-js: {}
     - deploy-ios-release: {}
     - deploy-android-release: {}
 
@@ -39,7 +39,7 @@ workflows:
         - command: install
     - save-npm-cache@1: {}
 
-  test-js:
+  _test-js:
     before_run:
     - _setup
     steps:
@@ -52,7 +52,7 @@ workflows:
   primary:
     description: Runs JavaScript tests and deploys a test report.
     steps:
-    - test-js: {}
+    - _test-js: {}
 
   deploy-ios-debug:
     before_run:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -51,8 +51,8 @@ workflows:
 
   primary:
     description: Runs JavaScript tests and deploys a test report.
-    steps:
-    - test-js: {}
+    before_run:
+    - test-js
 
   deploy-ios-debug:
     before_run:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -51,7 +51,7 @@ workflows:
     - custom-test-results-export:
         inputs:
         - test_name: Demo Test
-        - search_pattern: test-report.junit.xml
+        - search_pattern: *junit.xml
     - deploy-to-bitrise-io@2: {}
 
   primary:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -41,8 +41,6 @@ workflows:
     - save-npm-cache@1: {}
 
   test-js:
-    envs:
-    - JEST_JUNIT_OUTPUT_DIR: $BITRISE_DEPLOY_DIR
     before_run:
     - _setup
     steps:
@@ -50,6 +48,9 @@ workflows:
         title: Run tests
         inputs:
         - command: run test-ci
+    - custom-test-results-export:
+        inputs:
+        - search_pattern: test-report.junit.xml
     - deploy-to-bitrise-io@2: {}
 
   primary:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -71,6 +71,17 @@ workflows:
         - scheme: BitriseReactNativeSample
         - simulator_device: iPhone 13
         - configuration: Debug
+    - script@1:
+        inputs:
+        - content: |-
+            #!/usr/bin/env bash
+            # fail if any commands fails
+            set -e
+            # debug log
+            set -x
+            # zip the app package
+            cd $BITRISE_DEPLOY_DIR
+            zip -r React\ Native\ Demo.app.zip React\ Native\ Demo.app
     - deploy-to-bitrise-io@2: {}
     - save-cocoapods-cache@1: {}
 

--- a/ios/BitriseReactNativeSample.xcodeproj/project.pbxproj
+++ b/ios/BitriseReactNativeSample.xcodeproj/project.pbxproj
@@ -501,10 +501,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "iPhone Developer: Dev Portal Bot Bitrise (E89JV3W9K4)";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 72SA8V3WYL;
 				ENABLE_BITCODE = NO;
 				INFOPLIST_FILE = BitriseReactNativeSample/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "React Native Demo";
@@ -517,9 +518,10 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = io.bitrise.demoapps.reactnative;
 				PRODUCT_NAME = BitriseReactNativeSample;
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "BitriseBot-Wildcard";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -532,10 +534,11 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "iPhone Developer: Dev Portal Bot Bitrise (E89JV3W9K4)";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = 72SA8V3WYL;
 				INFOPLIST_FILE = BitriseReactNativeSample/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "React Native Demo";
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -547,9 +550,10 @@
 					"-ObjC",
 					"-lc++",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_BUNDLE_IDENTIFIER = io.bitrise.demoapps.reactnative;
 				PRODUCT_NAME = BitriseReactNativeSample;
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "BitriseBot-Wildcard";
 				SWIFT_VERSION = 5.0;
 				VERSIONING_SYSTEM = "apple-generic";
 			};

--- a/ios/BitriseReactNativeSample.xcodeproj/project.pbxproj
+++ b/ios/BitriseReactNativeSample.xcodeproj/project.pbxproj
@@ -31,7 +31,7 @@
 		00E356F11AD99517003FC87E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		00E356F21AD99517003FC87E /* BitriseReactNativeSampleTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BitriseReactNativeSampleTests.m; sourceTree = "<group>"; };
 		11E3343B88FB4F17949C137F /* Pods-React Native Demo-BitriseReactNativeSampleTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-React Native Demo-BitriseReactNativeSampleTests.release.xcconfig"; path = "Target Support Files/Pods-React Native Demo-BitriseReactNativeSampleTests/Pods-React Native Demo-BitriseReactNativeSampleTests.release.xcconfig"; sourceTree = "<group>"; };
-		13B07F961A680F5B00A75B9A /* BitriseReactNativeSample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BitriseReactNativeSample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		13B07F961A680F5B00A75B9A /* React Native Demo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "React Native Demo.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		13B07FAF1A68108700A75B9A /* AppDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = AppDelegate.h; path = BitriseReactNativeSample/AppDelegate.h; sourceTree = "<group>"; };
 		13B07FB01A68108700A75B9A /* AppDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = AppDelegate.mm; path = BitriseReactNativeSample/AppDelegate.mm; sourceTree = "<group>"; };
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = BitriseReactNativeSample/Images.xcassets; sourceTree = "<group>"; };
@@ -135,7 +135,7 @@
 		83CBBA001A601CBA00E9B192 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				13B07F961A680F5B00A75B9A /* BitriseReactNativeSample.app */,
+				13B07F961A680F5B00A75B9A /* React Native Demo.app */,
 				00E356EE1AD99517003FC87E /* BitriseReactNativeSampleTests.xctest */,
 			);
 			name = Products;
@@ -199,7 +199,7 @@
 			);
 			name = "React Native Demo";
 			productName = BitriseReactNativeSample;
-			productReference = 13B07F961A680F5B00A75B9A /* BitriseReactNativeSample.app */;
+			productReference = 13B07F961A680F5B00A75B9A /* React Native Demo.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -519,7 +519,7 @@
 					"-lc++",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = io.bitrise.demoapps.reactnative;
-				PRODUCT_NAME = BitriseReactNativeSample;
+				PRODUCT_NAME = "React Native Demo";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "BitriseBot-Wildcard";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -551,7 +551,7 @@
 					"-lc++",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = io.bitrise.demoapps.reactnative;
-				PRODUCT_NAME = BitriseReactNativeSample;
+				PRODUCT_NAME = "React Native Demo";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = "BitriseBot-Wildcard";
 				SWIFT_VERSION = 5.0;

--- a/ios/BitriseReactNativeSample/LaunchScreen.storyboard
+++ b/ios/BitriseReactNativeSample/LaunchScreen.storyboard
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15702" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15704"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -16,8 +17,8 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="BitriseReactNativeSample" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="GJd-Yh-RWb">
-                                <rect key="frame" x="0.0" y="202" width="375" height="43"/>
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Bitrise React Native Demo" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="GJd-Yh-RWb">
+                                <rect key="frame" x="8" y="202" width="359" height="43"/>
                                 <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
                                 <nil key="highlightedColor"/>
                             </label>
@@ -27,16 +28,16 @@
                                 <nil key="highlightedColor"/>
                             </label>
                         </subviews>
-                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="Bcu-3y-fUS"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="Bcu-3y-fUS" firstAttribute="bottom" secondItem="MN2-I3-ftu" secondAttribute="bottom" constant="20" id="OZV-Vh-mqD"/>
-                            <constraint firstItem="Bcu-3y-fUS" firstAttribute="centerX" secondItem="GJd-Yh-RWb" secondAttribute="centerX" id="Q3B-4B-g5h"/>
+                            <constraint firstItem="Bcu-3y-fUS" firstAttribute="trailing" secondItem="GJd-Yh-RWb" secondAttribute="trailing" constant="8" id="RIQ-1Y-rZM"/>
                             <constraint firstItem="MN2-I3-ftu" firstAttribute="centerX" secondItem="Bcu-3y-fUS" secondAttribute="centerX" id="akx-eg-2ui"/>
                             <constraint firstItem="MN2-I3-ftu" firstAttribute="leading" secondItem="Bcu-3y-fUS" secondAttribute="leading" id="i1E-0Y-4RG"/>
                             <constraint firstItem="GJd-Yh-RWb" firstAttribute="centerY" secondItem="Ze5-6b-2t3" secondAttribute="bottom" multiplier="1/3" constant="1" id="moa-c2-u7t"/>
-                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="leading" secondItem="Bcu-3y-fUS" secondAttribute="leading" symbolic="YES" id="x7j-FC-K8j"/>
+                            <constraint firstItem="GJd-Yh-RWb" firstAttribute="leading" secondItem="Bcu-3y-fUS" secondAttribute="leading" constant="8" id="x7j-FC-K8j"/>
                         </constraints>
-                        <viewLayoutGuide key="safeArea" id="Bcu-3y-fUS"/>
                     </view>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -44,4 +45,9 @@
             <point key="canvasLocation" x="52.173913043478265" y="375"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
       [
         "jest-junit",
         {
-          "outputName": "test-report.junit.xml"
+          "outputDirectory": "<rootDir>/reports",
+          "outputName": "test-report-junit.xml"
         }
       ]
     ]

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "ios": "react-native run-ios",
     "start": "react-native start",
     "test": "jest",
+    "test-ci": "jest --ci",
     "lint": "eslint .",
     "postinstall": "react-native-inhibit-warnings"
   },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "postinstall": "react-native-inhibit-warnings"
   },
   "dependencies": {
+    "jest-junit": "^15.0.0",
     "react": "18.2.0",
     "react-native": "0.71.1"
   },
@@ -27,6 +28,15 @@
     "react-test-renderer": "18.1.0"
   },
   "jest": {
-    "preset": "react-native"
+    "preset": "react-native",
+    "reporters": [
+      "default",
+      [
+        "jest-junit",
+        {
+          "outputName": "test-report.junit.xml"
+        }
+      ]
+    ]
   }
 }


### PR DESCRIPTION
## Context
\[[PLG-1349]\] We want demo app builds to generate artifacts of the executable apps for installation on mobile devices as well as export test reports.

## Changes
* Introduced `_setup` and `test` utility workflows in order to reduce repeated steps across workflows
* Made `primary` workflow use new `_test` utility workflow and deploy
* Modified `deploy` workflow to utilize the new `_test` utility workflow and generate a release app package
* Added `deploy-demo` to run tests and generate a debug simulator app package
* Added a trigger map to kick off `primary` workflow

## Decisions

[PLG-1349]: https://bitrise.atlassian.net/browse/PLG-1349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ